### PR TITLE
IssueN03

### DIFF
--- a/app/models/post_category.rb
+++ b/app/models/post_category.rb
@@ -1,0 +1,4 @@
+class PostCategory < ApplicationRecord
+  belongs_to :post
+  belongs_to :category
+end

--- a/db/migrate/20230724194603_create_post_categories.rb
+++ b/db/migrate/20230724194603_create_post_categories.rb
@@ -1,0 +1,10 @@
+class CreatePostCategories < ActiveRecord::Migration[7.0]
+  def change
+    create_table :post_categories do |t|
+      t.references :post, null: false, foreign_key: true
+      t.references :category, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_24_184211) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_24_194603) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_24_184211) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "post_categories", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.bigint "category_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_post_categories_on_category_id"
+    t.index ["post_id"], name: "index_post_categories_on_post_id"
+  end
+
   create_table "posts", force: :cascade do |t|
     t.string "title"
     t.text "content"
@@ -28,4 +37,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_24_184211) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "post_categories", "categories"
+  add_foreign_key "post_categories", "posts"
 end

--- a/spec/factories/post_categories.rb
+++ b/spec/factories/post_categories.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :post_category do
+    post { nil }
+    category { nil }
+  end
+end

--- a/spec/models/post_category_spec.rb
+++ b/spec/models/post_category_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe PostCategory, type: :model do
+
+  context "Testing factory" do
+    it "should not create PostCategory if not associated with a post" do
+      create(:category, name:'cat1', description:'kajfj')
+      expect(build(:post_category, category_id:1)).to be_invalid
+    end
+
+    it "should not create PostCategory if not associated with a category" do
+      create(:post, title:'Tit1', content:'contnrsohgs')
+      expect(build(:post_category, post_id:1)).to be_invalid
+    end
+
+    it "should create PostCategory" do
+      create(:post, id:1, title:'tit2', content:'content 2')
+      create(:category, id:1, name:'cat2', description:'desc 2')
+      expect(build(:post_category, post_id:1, category_id:1)).to be_valid
+    end
+  end
+
+end


### PR DESCRIPTION
Model PostCategory feita.

Essa foi a primeira model com relações com outras models, e seu processo de desenvolvimento foi um pouco diferente. Seus únicos atributos eram essas relações (com as models Post e Category).

Lembrando que podemos criar as relações como

```
rails g model PostCategory post:references category:references
```

o que gera as relações

```
belongs_to :post
belongs_to :category
```

automaticamente.